### PR TITLE
Hotfix ETP-1618: Improve task dependency management in PublicationConfiguration

### DIFF
--- a/src/main/groovy/com/etendoerp/publication/configuration/PublicationConfiguration.groovy
+++ b/src/main/groovy/com/etendoerp/publication/configuration/PublicationConfiguration.groovy
@@ -209,8 +209,13 @@ class PublicationConfiguration {
 
         // Add each task to the main project local publication
         def mainPublicationTask = project.tasks.findByName(mainProjectPublicationTaskName)
-        for (def subprojectTask : subprojectPublicationTasks) {
-            mainPublicationTask.dependsOn(subprojectTask)
+        for (int i = 0; i < subprojectPublicationTasks.size(); i++) {
+            def subprojectTask = subprojectPublicationTasks.get(i)
+            if (i == 0) {
+                mainPublicationTask.dependsOn(subprojectTask)
+            } else {
+                mainPublicationTask.mustRunAfter(subprojectTask)
+            }
         }
     }
 


### PR DESCRIPTION


Refactor the way subproject tasks are added to the main publication task. The first subproject task now uses 'dependsOn', while subsequent tasks use 'mustRunAfter' to ensure proper execution order.