### PR TITLE
Hotfix ETP-1813: Re-enable module tests

### DIFF
--- a/src/test/groovy/com/etendoerp/gradle/jars/resolution/compilation/ModulesCompilationTest.groovy
+++ b/src/test/groovy/com/etendoerp/gradle/jars/resolution/compilation/ModulesCompilationTest.groovy
@@ -44,11 +44,6 @@ class ModulesCompilationTest extends EtendoCoreResolutionSpecificationTest {
 
     @Unroll
     def "Compiling a module does not include the JAR module classpath if is already in Sources (coreType: #coreType)"() {
-        // Skip the test for "sources" coreType due to issues with Java path
-        if (coreType == "sources") {
-            println "Skipping test for coreType"
-            return
-        }
 
         given: "A Etendo core '#coreType'"
         addRepositoryToBuildFile(SNAPSHOT_REPOSITORY_URL)

--- a/src/test/groovy/com/etendoerp/gradle/tests/EtendoPluginPreReleaseTestsPart2.java
+++ b/src/test/groovy/com/etendoerp/gradle/tests/EtendoPluginPreReleaseTestsPart2.java
@@ -1,6 +1,5 @@
 package com.etendoerp.gradle.tests;
 
-import com.etendoerp.gradle.jars.dependencies.buildvalidations.ModuleValidationsTest;
 import com.etendoerp.gradle.jars.expand.ExpandTest;
 import com.etendoerp.gradle.jars.expand.expandModules.ExpandModulesNoOverwriteTest;
 import com.etendoerp.gradle.jars.expand.expandModules.ExpandModulesPkgFlagTest;
@@ -18,7 +17,6 @@ import org.junit.platform.suite.api.Suite;
 
 @Suite
 @SelectClasses({
-        //ModuleValidationsTest.class, // The problem is that the build validation system cannot find the compiled classes
         ExpandModulesNoOverwriteTest.class,
         ExpandModulesPkgFlagTest.class,
         ExpandTest.class,

--- a/src/test/groovy/com/etendoerp/gradle/tests/EtendoPluginSOSTests.java
+++ b/src/test/groovy/com/etendoerp/gradle/tests/EtendoPluginSOSTests.java
@@ -8,6 +8,7 @@ import com.etendoerp.gradle.jars.core.coreinjars.JarCoreCompilationTasksTest;
 import com.etendoerp.gradle.jars.core.coreinjars.JarCoreModulesInstallTest;
 import com.etendoerp.gradle.jars.core.coreinjars.JarCoreModulesUpdateTest;
 import com.etendoerp.gradle.jars.dependencies.ProjectWithEtendoCoreDependency;
+import com.etendoerp.gradle.jars.dependencies.buildvalidations.ModuleValidationsTest;
 import com.etendoerp.gradle.jars.expand.expandModules.ExpandModulesPkgNotFoundTest;
 import com.etendoerp.gradle.jars.expand.expandModules.ExpandModulesWithoutOverwriteTransitivesTest;
 import com.etendoerp.gradle.jars.extractresources.ExtractResourcesOfCoreJarTest;
@@ -61,7 +62,7 @@ import org.junit.platform.suite.api.Suite;
         BundleBuildFileCreationTest.class,
         BuildFileCreationAllModulesTest.class,
         CoreJarAutomaticUpdate.class,
-        //ModulesCompilationTest.class, // the module resolution system is not respecting the expected isolation between versions when using coreType: "jar".
+        ModulesCompilationTest.class,
         CoreExpandTransitiveModulesTest.class,
         ExpandCoreWithResolution.class,
         CoreModuleSkipExtractionTest.class,
@@ -73,7 +74,8 @@ import org.junit.platform.suite.api.Suite;
         SetupOmitCredentialsTest.class,
         SetupTest.class,
         ExpandCustomModuleTest.class,
-        ExpandTest.class
+        ExpandTest.class,
+        ModuleValidationsTest.class
 
 })
 public class EtendoPluginSOSTests {


### PR DESCRIPTION
- Enable ModulesCompilationTest in EtendoPluginSOSTests.java to ensure module resolution isolation is respected.
- Remove skip logic for "sources" coreType in ModulesCompilationTest to improve test coverage.