### PR TITLE
Feature ETP-2937: Make Java 17 mandatory and back to gradle 8.12

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionSha256Sum=a17ddd85a26b6a7f5ddb71ff8b05fc5104c0202c6e64782429790c933686c806
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/groovy/com/etendoerp/java/JavaCheckLoader.groovy
+++ b/src/main/groovy/com/etendoerp/java/JavaCheckLoader.groovy
@@ -13,16 +13,11 @@ class JavaCheckLoader {
             description = 'Verifies current Java version'
 
             doLast {
-                // Obtener la versión de Java actual
                 def javaVersion = System.getProperty('java.version')
                 def majorVersion = javaVersion.split('\\.')[0].toInteger()
 
-                def skipVersion = project.hasProperty('java.version') ?
-                        project.property('java.version').toInteger() : null
-
-                if (skipVersion != 11) {
-                    if (majorVersion < 17) {
-                        throw new GradleException("""
+                if (majorVersion < 17) {
+                    throw new GradleException("""
                     |--------------------------------------------------
                     | ERROR: Incompatible Java Version
                     |--------------------------------------------------
@@ -34,25 +29,13 @@ class JavaCheckLoader {
                     | 2. Use a version manager like SDKMAN! (https://sdkman.io/)
                     |    to manage multiple Java versions easily.
                     | 3. Update your JAVA_HOME environment variable to point to the new version.
-                    | 4. Optionally download and install Java 17 (or higher) from:
+                    | 4. Download and install Java 17 (or higher) from:
                     |    - https://adoptium.net/ (recommended)
                     |    - Or from Oracle's official site: https://www.oracle.com/java/
-                    |
-                    | Alternative (DEPRECATED - Not Recommended):
-                    | If you absolutely cannot update Java, you can temporarily skip this validation
-                    | by running the command with the flag: -Pjava.version=11
-                    | Example: ./gradlew smartbuild -Pjava.version=11
-                    | Or, you can add the following to your gradle.properties file to override this check (at your own risk):
-                    |   java.version=11
-                    | **WARNING**: This option is deprecated and should only be used for legacy maintenance tasks.
-                    | Using this flag may lead to compatibility issues and is not supported for regular development.
                     |--------------------------------------------------
                 """.stripMargin())
-                    } else {
-                        project.logger.info("Detected Java version: ${javaVersion}")
-                    }
                 } else {
-                    project.logger.info("Skipping Java version check")
+                    project.logger.info("Detected Java version: ${javaVersion}")
                 }
             }
         }


### PR DESCRIPTION
This pull request updates the Java version validation logic and the Gradle wrapper configuration to enforce stricter requirements for Java 17 or higher. The main changes remove the deprecated option to bypass the Java version check and downgrade the Gradle wrapper version.

**Build system and Java version enforcement:**

* Downgraded the Gradle wrapper from version 9.1.0 to 8.12.1 in `gradle-wrapper.properties`.

**Java version check improvements:**

* Removed the ability to skip the Java version check by setting the `java.version` property, enforcing a strict requirement for Java 17 or higher in `JavaCheckLoader.groovy`.
* Updated the user guidance message to eliminate deprecated instructions for bypassing the Java version check, clarifying that only Java 17 or higher is supported.