### PR TITLE
Feature ETP-3290: Implement cleanup functionality for OB.properties

### DIFF
--- a/src/main/groovy/com/etendoerp/legacy/LegacyScriptLoader.groovy
+++ b/src/main/groovy/com/etendoerp/legacy/LegacyScriptLoader.groovy
@@ -329,6 +329,56 @@ class LegacyScriptLoader {
             doLast {
                 def props = new Properties()
                 project.file("gradle.properties").withInputStream { props.load(it) }
+
+                // If the 'cleanSync' property is set to true, we will remove all the properties that are not in the gradle.properties 
+                // or in the template, to ensure a clean sync with the gradle.properties values.
+                if (project.hasProperty('cleanUp')) {
+                    project.logger.info("-------------Cleaning up Openbravo.properties-------------")
+                    def openbravoPropertiesFile = project.file("config/Openbravo.properties")
+                    if (openbravoPropertiesFile.exists()) {
+                        // Backup
+                        def timestamp = new java.text.SimpleDateFormat("yyyyMMdd_HHmmss").format(new Date())
+                        def backupFile = project.file("config/Openbravo.properties.backup.${timestamp}")
+                        project.copy {
+                            from openbravoPropertiesFile
+                            into project.file("config")
+                            rename { fileName -> "Openbravo.properties.backup.${timestamp}" }
+                        }
+                        project.logger.info("Backed up Openbravo.properties to ${backupFile.name}")
+
+                        // Load current Openbravo.properties
+                        def openbravoProps = new Properties()
+                        openbravoPropertiesFile.withInputStream { openbravoProps.load(it) }
+
+                        // Load template properties
+                        def templateProps = new Properties()
+                        if (project.file("config/Openbravo.properties.template").exists()) {
+                            project.file("config/Openbravo.properties.template").withInputStream { templateProps.load(it) }
+                        }
+
+                        // Identify properties to remove
+                        def keysToRemove = []
+                        openbravoProps.stringPropertyNames().each { key ->
+                            if (!props.containsKey(key) && !templateProps.containsKey(key)) {
+                                keysToRemove.add(key)
+                            }
+                        }
+
+                        // Remove properties
+                        if (!keysToRemove.isEmpty()) {
+                            // We use ant.propertyfile to remove keys.
+                            // The 'operation' attribute with value 'del' removes the property.
+                            ant.propertyfile(file: "config/Openbravo.properties") {
+                                keysToRemove.each { key ->
+                                    entry(key: key, operation: "del")
+                                    project.logger.info("Removed property: ${key}")
+                                }
+                            }
+                        }
+                    }
+                    project.logger.info("-------------Finished cleaning up Openbravo.properties-------------")
+                }
+
                 ant.propertyfile(file: "config/Openbravo.properties") {
 
                     // Find all properties in gradle.properties and set their value in Openbravo.properties

--- a/src/test/groovy/com/etendoerp/gradle/tests/configuration/PrepareConfigTest.groovy
+++ b/src/test/groovy/com/etendoerp/gradle/tests/configuration/PrepareConfigTest.groovy
@@ -156,4 +156,49 @@ class PrepareConfigTest extends EtendoSpecification {
         }
     }
 
+    def "Clean up Openbravo.properties with -PcleanUp"() {
+        given: "a configured gradle.properties"
+        addRepositoryToBuildFileFirst(SNAPSHOT_REPOSITORY_URL)
+
+        def gradleProperties = new File(testProjectDir, "gradle.properties")
+        gradleProperties.text = """
+        context.name=test_etendo
+        nexusUser=
+        nexusPassword=
+        githubUser=
+        githubToken=
+        """
+
+        and: "running the first 'prepareConfig' task"
+        def expandResult = runTask("expandCore")
+        def firstSetupResult = runTask("prepareConfig")
+        expandResult.task(":expandCore").outcome == TaskOutcome.SUCCESS
+        firstSetupResult.task(":prepareConfig").outcome == TaskOutcome.UP_TO_DATE || TaskOutcome.SUCCESS
+
+        and: "adding an extra property to Openbravo.properties that is not in gradle.properties"
+        def propsFile = new File(testProjectDir, "config/Openbravo.properties")
+        def props = new Properties()
+        props.load(propsFile.newReader())
+        props.setProperty("extra.property", "extraValue")
+        props.store(propsFile.newWriter(), null)
+
+        when: "running the 'prepareConfig' task with -PcleanUp"
+        def result = runTask("prepareConfig", "-PcleanUp")
+
+        then: "the extra property is removed and a backup is created"
+        def finalProps = new Properties()
+        finalProps.load(propsFile.newReader())
+
+        def configDir = new File(testProjectDir, "config")
+        def backupFile = configDir.listFiles().find { it.name.startsWith("Openbravo.properties.backup.") }
+
+        verifyAll {
+            result.task(":prepareConfig").outcome == TaskOutcome.UP_TO_DATE || TaskOutcome.SUCCESS
+            !finalProps.containsKey("extra.property")
+            finalProps.getProperty("context.name") == "test_etendo"
+            backupFile != null
+            backupFile.exists()
+        }
+    }
+
 }


### PR DESCRIPTION
Added a new property cleanup feature in the 'prepareConfig' task to remove unwanted properties from Openbravo.properties when the '-PcleanUp' flag is used. This includes backing up the existing properties file before cleanup.