### PR TITLE
Issue #1017: Support MODULES_CORE list resolution as Etendo JAR modules

### DIFF
--- a/src/main/groovy/com/etendoerp/dependencies/EtendoCoreDependencies.groovy
+++ b/src/main/groovy/com/etendoerp/dependencies/EtendoCoreDependencies.groovy
@@ -1,9 +1,16 @@
 package com.etendoerp.dependencies
 
+import com.etendoerp.legacy.dependencies.container.ArtifactDependency
 import com.etendoerp.legacy.utils.NexusUtils
+import org.gradle.api.GradleException
 import org.gradle.api.Project
 
 class EtendoCoreDependencies {
+
+    static final String DEPENDENCIES_LIST_COMPILATION = "dependenciesListCOMPILATION"
+    static final String DEPENDENCIES_LIST_MODULES_CORE = "dependenciesListMODULESCORE"
+    static final String MODULES_CORE_DEPENDENCIES_TO_VALIDATE = "modulesCoreDependenciesToValidate"
+    static final String MODULES_CORE_DEPENDENCIES_TO_RESOLVE = "modulesCoreDependenciesToResolve"
 
     static void loadCoreCompilationDependencies(Project project) {
         // Listing jar files - scope: COMPILATION
@@ -34,31 +41,130 @@ class EtendoCoreDependencies {
     }
 
     static List<String> loadDependenciesFromFile(Project project) {
-        File depsFile = project.file('artifacts.list.COMPILATION.gradle')
-        if (!depsFile.exists()) {
-            project.logger.error("The file ${depsFile.path} does not exist.")
-            return []
-        }
-
-        Binding binding = new Binding()
-        def extMap = [:]
-        binding.setVariable'ext', { Closure closure ->
-            closure.delegate = extMap
-            closure.resolveStrategy = Closure.DELEGATE_FIRST
-            closure()
-        }
-
-        GroovyShell shell = new GroovyShell(binding)
-
-        shell.evaluate(depsFile)
-
-        def dependenciesList = extMap.dependenciesListCOMPILATION ?: []
+        def dependenciesList = loadArtifactsList(project, DEPENDENCIES_LIST_COMPILATION)
 
         if (!dependenciesList) {
             project.logger.error("Artifacts list is empty.")
         }
 
         return dependenciesList
+    }
+
+    static List<String> loadModulesCoreDependenciesFromFile(Project project) {
+        return loadArtifactsList(project, DEPENDENCIES_LIST_MODULES_CORE)
+    }
+
+    static Map loadArtifactsLists(Project project) {
+        File depsFile = project.file('artifacts.list.COMPILATION.gradle')
+        if (!depsFile.exists()) {
+            project.logger.error("The file ${depsFile.path} does not exist.")
+            return [:]
+        }
+
+        Binding binding = new Binding()
+        def extMap = [:]
+        binding.setVariable 'ext', { Closure closure ->
+            closure.delegate = extMap
+            closure.resolveStrategy = Closure.DELEGATE_FIRST
+            closure()
+        }
+
+        GroovyShell shell = new GroovyShell(binding)
+        shell.evaluate(depsFile)
+
+        return extMap
+    }
+
+    static List<String> loadArtifactsList(Project project, String listName) {
+        def extMap = loadArtifactsLists(project)
+        def dependenciesList = extMap[listName] ?: []
+
+        if (!(dependenciesList instanceof List)) {
+            throw new GradleException("The '${listName}' property in artifacts.list.COMPILATION.gradle must be a List<String>.")
+        }
+
+        return dependenciesList as List<String>
+    }
+
+    static void loadModulesCoreDependencies(Project project) {
+        def modulesCoreDependencies = loadModulesCoreDependenciesFromFile(project)
+        if (!modulesCoreDependencies) {
+            project.ext.set(MODULES_CORE_DEPENDENCIES_TO_VALIDATE, [] as Set)
+            project.ext.set(MODULES_CORE_DEPENDENCIES_TO_RESOLVE, [] as List)
+            return
+        }
+
+        def compilationDependencies = loadDependenciesFromFile(project)
+        validateNoDuplicatesWithCompilation(project, modulesCoreDependencies, compilationDependencies)
+
+        Set<String> dependenciesToValidate = new TreeSet<>(String.CASE_INSENSITIVE_ORDER)
+        List<String> dependenciesToResolve = []
+
+        project.dependencies {
+            modulesCoreDependencies.each { String dependency ->
+                validateModulesCoreDependencyNotation(dependency)
+
+                String moduleName = getModuleName(dependency)
+                if (isSourceModuleAvailable(project, moduleName)) {
+                    project.logger.warn("Module '${moduleName}' is declared in ${DEPENDENCIES_LIST_MODULES_CORE} but exists in modules_core. Using source module and skipping JAR module dependency '${dependency}'.")
+                    return
+                }
+
+                dependenciesToValidate.add(moduleName)
+                dependenciesToResolve.add(dependency)
+                implementation(dependency) { transitive = true }
+            }
+        }
+
+        project.ext.set(MODULES_CORE_DEPENDENCIES_TO_VALIDATE, dependenciesToValidate)
+        project.ext.set(MODULES_CORE_DEPENDENCIES_TO_RESOLVE, dependenciesToResolve)
+    }
+
+    static void validateNoDuplicatesWithCompilation(Project project, List<String> modulesCoreDependencies, List<String> compilationDependencies) {
+        Set<String> compilation = new TreeSet<>(String.CASE_INSENSITIVE_ORDER)
+        compilationDependencies.each { compilation.add(normalizeDependencyKey(it)) }
+
+        modulesCoreDependencies.each { String dependency ->
+            String dependencyKey = normalizeDependencyKey(dependency)
+            if (compilation.contains(dependencyKey)) {
+                throw new GradleException("Dependency '${dependency}' is declared in both ${DEPENDENCIES_LIST_MODULES_CORE} and ${DEPENDENCIES_LIST_COMPILATION}. Modules core dependencies must be removed from ${DEPENDENCIES_LIST_COMPILATION}.")
+            }
+        }
+    }
+
+    static void validateModulesCoreDependencyNotation(String dependency) {
+        if (!dependency || dependency.isBlank()) {
+            throw new GradleException("${DEPENDENCIES_LIST_MODULES_CORE} contains an empty dependency entry.")
+        }
+        if (dependency.contains("@")) {
+            throw new GradleException("${DEPENDENCIES_LIST_MODULES_CORE} only supports JAR module dependencies. Remove the explicit extension from '${dependency}'.")
+        }
+        def parts = dependency.split(":")
+        if (parts.length != 3 || parts.any { it == null || it.isBlank() }) {
+            throw new GradleException("Invalid dependency '${dependency}' in ${DEPENDENCIES_LIST_MODULES_CORE}. Expected format: 'group:artifact:version'.")
+        }
+    }
+
+    static String normalizeDependencyKey(String dependency) {
+        def dependencyWithoutExtension = dependency.contains("@") ? dependency.substring(0, dependency.indexOf("@")) : dependency
+        def parts = dependencyWithoutExtension.split(":")
+        if (parts.length < 2) {
+            return dependencyWithoutExtension
+        }
+        return "${parts[0]}:${parts[1]}"
+    }
+
+    static String getModuleName(String dependency) {
+        def parts = dependency.split(":")
+        return ArtifactDependency.buildModuleName(parts[0], parts[1])
+    }
+
+    static boolean isSourceModuleAvailable(Project project, String moduleName) {
+        File modulesCoreDir = new File(project.rootDir, "modules_core")
+        if (!modulesCoreDir.exists()) {
+            return false
+        }
+        return modulesCoreDir.listFiles()?.any { it.isDirectory() && it.name.equalsIgnoreCase(moduleName) } ?: false
     }
 
     static void loadCoreTestDependencies(Project project) {

--- a/src/main/groovy/com/etendoerp/legacy/dependencies/DependencyProcessor.groovy
+++ b/src/main/groovy/com/etendoerp/legacy/dependencies/DependencyProcessor.groovy
@@ -3,6 +3,7 @@ package com.etendoerp.legacy.dependencies
 import com.etendoerp.EtendoPluginExtension
 import com.etendoerp.core.CoreMetadata
 import com.etendoerp.core.CoreType
+import com.etendoerp.dependencies.EtendoCoreDependencies
 import com.etendoerp.jars.modules.metadata.DependencyUtils
 import com.etendoerp.legacy.dependencies.container.ArtifactDependency
 import com.etendoerp.legacy.dependencies.container.DependencyContainer
@@ -111,6 +112,21 @@ class DependencyProcessor {
         return dependencies
     }
 
+    void loadModulesCoreDependenciesToResolutionContainer(Configuration container) {
+        if (!project.ext.has(EtendoCoreDependencies.MODULES_CORE_DEPENDENCIES_TO_RESOLVE)) {
+            return
+        }
+
+        List<String> modulesCoreDependencies = project.ext.get(EtendoCoreDependencies.MODULES_CORE_DEPENDENCIES_TO_RESOLVE) as List<String>
+        modulesCoreDependencies.each { String dependency ->
+            Dependency moduleDependency = project.dependencies.create(dependency) as Dependency
+            if (moduleDependency.hasProperty('transitive')) {
+                moduleDependency.transitive = true
+            }
+            container.dependencies.add(moduleDependency)
+        }
+    }
+
     Map<String, List<ArtifactDependency>> performResolutionConflict(Configuration container, boolean addCoreToResolution, boolean filterCoreDependency) {
         // Create a temporal configuration container used to perform resolution conflicts
         def resolutionContainer = container.copyRecursive()
@@ -139,6 +155,7 @@ class DependencyProcessor {
     void loadDependenciesFiles(boolean addCoreToResolution, boolean performResolutionConflicts , boolean filterCoreDependency) {
         // Load all project and subproject dependencies in a custom configuration container
         Configuration container = ResolverDependencyUtils.loadResolutionDependencies(project)
+        loadModulesCoreDependenciesToResolutionContainer(container)
 
         // Load the CORE dependencies
         if (coreMetadata.coreType == CoreType.SOURCES && project.extensions.findByType(EtendoPluginExtension).loadCoreDependencies) {
@@ -174,6 +191,7 @@ class DependencyProcessor {
         // Filter maven and Etendo dependencies
         this.dependencyContainer.configuration = container
         this.dependencyContainer.filterDependenciesFiles()
+        validateModulesCoreDependenciesAreEtendoJarModules()
 
         // Configure the subprojects to use the filtered dependencies
         def artifacts = this.dependencyContainer.etendoDependenciesJarFiles.entrySet().collect({
@@ -183,6 +201,31 @@ class DependencyProcessor {
         })
 
         ModulesConfigurationUtils.configureVersionReplacer(project, DependencyContainer.parseArtifactDependency(project, artifacts))
+    }
+
+    void validateModulesCoreDependenciesAreEtendoJarModules() {
+        Set<String> modulesCoreDependenciesToValidate = [] as Set
+        if (project.ext.has(EtendoCoreDependencies.MODULES_CORE_DEPENDENCIES_TO_VALIDATE)) {
+            modulesCoreDependenciesToValidate = project.ext.get(EtendoCoreDependencies.MODULES_CORE_DEPENDENCIES_TO_VALIDATE) as Set<String>
+        }
+
+        modulesCoreDependenciesToValidate.each { String moduleName ->
+            ArtifactDependency artifactDependency = this.dependencyContainer.etendoDependenciesJarFiles.get(moduleName)
+            if (!artifactDependency) {
+                throw new IllegalArgumentException("Dependency '${moduleName}' is declared in ${EtendoCoreDependencies.DEPENDENCIES_LIST_MODULES_CORE} but the resolved JAR is not an Etendo module JAR. Make sure the artifact contains Etendo module metadata and AD_MODULE.xml.")
+            }
+            if (!containsADModuleFile(artifactDependency)) {
+                throw new IllegalArgumentException("Dependency '${artifactDependency.displayName}' is declared in ${EtendoCoreDependencies.DEPENDENCIES_LIST_MODULES_CORE} but the resolved JAR does not contain AD_MODULE.xml.")
+            }
+        }
+    }
+
+    boolean containsADModuleFile(ArtifactDependency artifactDependency) {
+        def adModulePath = "${ArtifactDependency.JAR_ETENDO_MODULE_LOCATION}/${artifactDependency.moduleName}/src-db/database/sourcedata/AD_MODULE.xml"
+        def adModuleTree = project.zipTree(artifactDependency.locationFile).matching {
+            include adModulePath
+        }
+        return adModuleTree && adModuleTree.size() >= 1
     }
 
     void updateContainerPreFilterCoreSources(Configuration container, ArtifactDependency coreArtifactDependency) {

--- a/src/main/groovy/com/etendoerp/legacy/dependencies/ResolverDependencyLoader.groovy
+++ b/src/main/groovy/com/etendoerp/legacy/dependencies/ResolverDependencyLoader.groovy
@@ -59,6 +59,9 @@ class ResolverDependencyLoader {
         EtendoCoreDependencies.loadCoreCompilationDependencies(project)
       }
 
+      // Load modules_core dependencies resolved as Etendo JAR modules
+      EtendoCoreDependencies.loadModulesCoreDependencies(project)
+
       // Load Etendo core test dependencies
       if (loadTestDependencies) {
         EtendoCoreDependencies.loadCoreTestDependencies(project)

--- a/src/main/groovy/com/etendoerp/legacy/dependencies/container/ArtifactDependency.groovy
+++ b/src/main/groovy/com/etendoerp/legacy/dependencies/container/ArtifactDependency.groovy
@@ -109,7 +109,7 @@ class ArtifactDependency {
         this.group = moduleVersionIdentifier.group.toLowerCase()
         this.name = moduleVersionIdentifier.name.toLowerCase()
         this.version = moduleVersionIdentifier.version
-        this.moduleName = "${this.group}.${this.name}"
+        this.moduleName = buildModuleName(this.group, this.name)
     }
 
     static String replaceSnapshot(String displayName) {
@@ -124,7 +124,7 @@ class ArtifactDependency {
         this.group = group
         this.name = name
         this.version = version
-        this.moduleName = "${this.group}.${this.name}"
+        this.moduleName = buildModuleName(this.group, this.name)
     }
 
     void loadFromArtifact() {
@@ -134,8 +134,18 @@ class ArtifactDependency {
         this.name         = this.resolvedArtifact.moduleVersion.id.name
         this.version      = this.resolvedArtifact.moduleVersion.id.version
         this.extension    = this.resolvedArtifact.extension
-        this.moduleName   = "${this.group}.${this.name}"
+        this.moduleName   = buildModuleName(this.group, this.name)
         this.displayName  = "${this.group}:${this.name}:${this.version}"
+    }
+
+    static String buildModuleName(String group, String name) {
+        if (name == null || name.isBlank()) {
+            return name
+        }
+        if (group == null || group.isBlank()) {
+            return name
+        }
+        return name.equalsIgnoreCase(group) || name.toLowerCase().startsWith("${group.toLowerCase()}.") ? name : "${group}.${name}"
     }
 
     void extract() {}

--- a/src/main/groovy/com/etendoerp/legacy/dependencies/container/DependencyContainer.groovy
+++ b/src/main/groovy/com/etendoerp/legacy/dependencies/container/DependencyContainer.groovy
@@ -121,6 +121,7 @@ class DependencyContainer {
         FileTree unzipDependency = project.zipTree(resolvedArtifact.file)
         def etendoModulesTree = unzipDependency.matching {
             include "${ArtifactDependency.JAR_ETENDO_MODULE_LOCATION}"
+            include "${ArtifactDependency.JAR_ETENDO_MODULE_LOCATION}/**"
         }
 
         // The dependency file is a Etendo module

--- a/src/main/groovy/com/etendoerp/legacy/dependencies/container/EtendoJarModuleArtifact.groovy
+++ b/src/main/groovy/com/etendoerp/legacy/dependencies/container/EtendoJarModuleArtifact.groovy
@@ -57,7 +57,7 @@ class EtendoJarModuleArtifact extends ArtifactDependency{
         FileTree moduleFileTree = project.zipTree(this.locationFile)
 
         def metainfFilter = moduleFileTree.matching {
-            include "${JAR_ETENDO_LOCATION}"
+            include "${JAR_ETENDO_MODULE_LOCATION}/${this.moduleName}/**"
         }
 
         def srcFilter = moduleFileTree.matching {

--- a/src/test/groovy/com/etendoerp/dependencies/EtendoCoreDependenciesSpec.groovy
+++ b/src/test/groovy/com/etendoerp/dependencies/EtendoCoreDependenciesSpec.groovy
@@ -1,0 +1,192 @@
+/*
+ *************************************************************************
+ * The contents of this file are subject to the Etendo License
+ * (the "License"), you may not use this file except in compliance
+ * with the License.
+ * You may obtain a copy of the License at
+ * https://github.com/etendosoftware/etendo_core/blob/main/legal/Etendo_license.txt
+ * Software distributed under the License is distributed on an
+ * "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing rights
+ * and limitations under the License.
+ * All portions are Copyright (C) 2021-2026 FUTIT SERVICES, S.L
+ * All Rights Reserved.
+ * Contributor(s): Futit Services S.L.
+ *************************************************************************
+ */
+package com.etendoerp.dependencies
+
+import org.gradle.api.GradleException
+import org.gradle.testfixtures.ProjectBuilder
+import spock.lang.Specification
+import spock.lang.TempDir
+
+class EtendoCoreDependenciesSpec extends Specification {
+
+    @TempDir
+    File testProjectDir
+
+    def project
+
+    def setup() {
+        project = ProjectBuilder.builder()
+                .withProjectDir(testProjectDir)
+                .build()
+        project.pluginManager.apply('java')
+    }
+
+    def "loads modules core dependencies from artifacts list"() {
+        given:
+        writeArtifactsList("""
+            List<String> _dependenciesListCOMPILATION = [
+              'org.postgresql:postgresql:42.7.8'
+            ]
+            List<String> _dependenciesListMODULESCORE = [
+              'com.test:modulea:1.0.0',
+              'com.test:moduleb:2.0.0'
+            ]
+            ext {
+              dependenciesListCOMPILATION = _dependenciesListCOMPILATION
+              dependenciesListMODULESCORE = _dependenciesListMODULESCORE
+            }
+        """)
+
+        expect:
+        EtendoCoreDependencies.loadModulesCoreDependenciesFromFile(project) == [
+                'com.test:modulea:1.0.0',
+                'com.test:moduleb:2.0.0'
+        ]
+    }
+
+    def "adds modules core dependencies as transitive implementation dependencies"() {
+        given:
+        writeArtifactsList("""
+            List<String> _dependenciesListCOMPILATION = [
+              'org.postgresql:postgresql:42.7.8'
+            ]
+            List<String> _dependenciesListMODULESCORE = [
+              'com.test:modulea:1.0.0'
+            ]
+            ext {
+              dependenciesListCOMPILATION = _dependenciesListCOMPILATION
+              dependenciesListMODULESCORE = _dependenciesListMODULESCORE
+            }
+        """)
+
+        when:
+        EtendoCoreDependencies.loadModulesCoreDependencies(project)
+
+        then:
+        def dependency = project.configurations.implementation.dependencies.find {
+            it.group == 'com.test' && it.name == 'modulea' && it.version == '1.0.0'
+        }
+        dependency != null
+        dependency.transitive
+        project.ext.get(EtendoCoreDependencies.MODULES_CORE_DEPENDENCIES_TO_VALIDATE) == ['com.test.modulea'] as Set
+        project.ext.get(EtendoCoreDependencies.MODULES_CORE_DEPENDENCIES_TO_RESOLVE) == ['com.test:modulea:1.0.0']
+    }
+
+    def "source module wins over modules core jar dependency"() {
+        given:
+        new File(testProjectDir, 'modules_core/com.test.modulea').mkdirs()
+        writeArtifactsList("""
+            List<String> _dependenciesListCOMPILATION = []
+            List<String> _dependenciesListMODULESCORE = [
+              'com.test:modulea:1.0.0'
+            ]
+            ext {
+              dependenciesListCOMPILATION = _dependenciesListCOMPILATION
+              dependenciesListMODULESCORE = _dependenciesListMODULESCORE
+            }
+        """)
+
+        when:
+        EtendoCoreDependencies.loadModulesCoreDependencies(project)
+
+        then:
+        !project.configurations.implementation.dependencies.any {
+            it.group == 'com.test' && it.name == 'modulea'
+        }
+        project.ext.get(EtendoCoreDependencies.MODULES_CORE_DEPENDENCIES_TO_VALIDATE).isEmpty()
+        project.ext.get(EtendoCoreDependencies.MODULES_CORE_DEPENDENCIES_TO_RESOLVE).isEmpty()
+    }
+
+    def "fails when modules core dependency is also declared as compilation dependency"() {
+        given:
+        writeArtifactsList("""
+            List<String> _dependenciesListCOMPILATION = [
+              'com.test:modulea:1.0.0'
+            ]
+            List<String> _dependenciesListMODULESCORE = [
+              'com.test:modulea:2.0.0'
+            ]
+            ext {
+              dependenciesListCOMPILATION = _dependenciesListCOMPILATION
+              dependenciesListMODULESCORE = _dependenciesListMODULESCORE
+            }
+        """)
+
+        when:
+        EtendoCoreDependencies.loadModulesCoreDependencies(project)
+
+        then:
+        def ex = thrown(GradleException)
+        ex.message.contains('declared in both')
+    }
+
+    def "fails when modules core dependency declares an explicit extension"() {
+        given:
+        writeArtifactsList("""
+            List<String> _dependenciesListCOMPILATION = []
+            List<String> _dependenciesListMODULESCORE = [
+              'com.test:modulea:1.0.0@zip'
+            ]
+            ext {
+              dependenciesListCOMPILATION = _dependenciesListCOMPILATION
+              dependenciesListMODULESCORE = _dependenciesListMODULESCORE
+            }
+        """)
+
+        when:
+        EtendoCoreDependencies.loadModulesCoreDependencies(project)
+
+        then:
+        def ex = thrown(GradleException)
+        ex.message.contains('only supports JAR module dependencies')
+    }
+
+    def "gets module name when artifact is a suffix of the package"() {
+        expect:
+        EtendoCoreDependencies.getModuleName('com.etendoerp:analytics.exporter:3.3.0') == 'com.etendoerp.analytics.exporter'
+    }
+
+    def "gets module name when artifact is already the full package"() {
+        expect:
+        EtendoCoreDependencies.getModuleName('com.etendoerp:com.etendoerp.analytics.exporter:3.3.0') == 'com.etendoerp.analytics.exporter'
+    }
+
+    def "fails when modules core dependency notation is incomplete"() {
+        given:
+        writeArtifactsList("""
+            List<String> _dependenciesListCOMPILATION = []
+            List<String> _dependenciesListMODULESCORE = [
+              'com.test:modulea'
+            ]
+            ext {
+              dependenciesListCOMPILATION = _dependenciesListCOMPILATION
+              dependenciesListMODULESCORE = _dependenciesListMODULESCORE
+            }
+        """)
+
+        when:
+        EtendoCoreDependencies.loadModulesCoreDependencies(project)
+
+        then:
+        def ex = thrown(GradleException)
+        ex.message.contains("Expected format: 'group:artifact:version'")
+    }
+
+    private void writeArtifactsList(String content) {
+        new File(testProjectDir, 'artifacts.list.COMPILATION.gradle').text = content.stripIndent()
+    }
+}

--- a/src/test/groovy/com/etendoerp/legacy/dependencies/DependencyProcessorModulesCoreSpec.groovy
+++ b/src/test/groovy/com/etendoerp/legacy/dependencies/DependencyProcessorModulesCoreSpec.groovy
@@ -1,0 +1,129 @@
+/*
+ *************************************************************************
+ * The contents of this file are subject to the Etendo License
+ * (the "License"), you may not use this file except in compliance
+ * with the License.
+ * You may obtain a copy of the License at
+ * https://github.com/etendosoftware/etendo_core/blob/main/legal/Etendo_license.txt
+ * Software distributed under the License is distributed on an
+ * "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing rights
+ * and limitations under the License.
+ * All portions are Copyright (C) 2026 FUTIT SERVICES, S.L
+ * All Rights Reserved.
+ * Contributor(s): Futit Services S.L.
+ *************************************************************************
+ */
+package com.etendoerp.legacy.dependencies
+
+import com.etendoerp.dependencies.EtendoCoreDependencies
+import com.etendoerp.legacy.dependencies.container.ArtifactDependency
+import com.etendoerp.legacy.dependencies.container.DependencyContainer
+import com.etendoerp.legacy.dependencies.container.DependencyType
+import org.gradle.testfixtures.ProjectBuilder
+import spock.lang.Specification
+import spock.lang.TempDir
+
+import java.util.jar.JarEntry
+import java.util.jar.JarOutputStream
+
+class DependencyProcessorModulesCoreSpec extends Specification {
+
+    @TempDir
+    File testProjectDir
+
+    def project
+    DependencyProcessor processor
+
+    def setup() {
+        project = ProjectBuilder.builder()
+                .withProjectDir(testProjectDir)
+                .build()
+        processor = new DependencyProcessor(project, null)
+        processor.dependencyContainer = new DependencyContainer(project, null)
+    }
+
+    def "validates declared modules core dependency when resolved as Etendo JAR module with AD_MODULE"() {
+        given:
+        def artifact = artifactDependency('com.test.modulea', jarWithEntries([
+                'META-INF/etendo/modules/com.test.modulea/src-db/database/sourcedata/AD_MODULE.xml'
+        ]))
+        processor.dependencyContainer.etendoDependenciesJarFiles.put('com.test.modulea', artifact)
+        project.ext.set(EtendoCoreDependencies.MODULES_CORE_DEPENDENCIES_TO_VALIDATE, ['com.test.modulea'] as Set)
+
+        when:
+        processor.validateModulesCoreDependenciesAreEtendoJarModules()
+
+        then:
+        noExceptionThrown()
+    }
+
+    def "fails when declared modules core dependency was not resolved as Etendo JAR module"() {
+        given:
+        project.ext.set(EtendoCoreDependencies.MODULES_CORE_DEPENDENCIES_TO_VALIDATE, ['com.test.modulea'] as Set)
+
+        when:
+        processor.validateModulesCoreDependenciesAreEtendoJarModules()
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('not an Etendo module JAR')
+    }
+
+    def "fails when declared modules core dependency JAR does not contain AD_MODULE"() {
+        given:
+        def artifact = artifactDependency('com.test.modulea', jarWithEntries([
+                'META-INF/etendo/modules/com.test.modulea/README.md'
+        ]))
+        processor.dependencyContainer.etendoDependenciesJarFiles.put('com.test.modulea', artifact)
+        project.ext.set(EtendoCoreDependencies.MODULES_CORE_DEPENDENCIES_TO_VALIDATE, ['com.test.modulea'] as Set)
+
+        when:
+        processor.validateModulesCoreDependenciesAreEtendoJarModules()
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('does not contain AD_MODULE.xml')
+    }
+
+    def "detects AD_MODULE inside Etendo module JAR"() {
+        given:
+        def artifact = artifactDependency('com.test.modulea', jarWithEntries([
+                'META-INF/etendo/modules/com.test.modulea/src-db/database/sourcedata/AD_MODULE.xml'
+        ]))
+
+        expect:
+        processor.containsADModuleFile(artifact)
+    }
+
+    def "does not detect AD_MODULE when path belongs to a different module"() {
+        given:
+        def artifact = artifactDependency('com.test.modulea', jarWithEntries([
+                'META-INF/etendo/modules/com.test.other/src-db/database/sourcedata/AD_MODULE.xml'
+        ]))
+
+        expect:
+        !processor.containsADModuleFile(artifact)
+    }
+
+    private ArtifactDependency artifactDependency(String moduleName, File jarFile) {
+        def artifact = new ArtifactDependency(project)
+        artifact.moduleName = moduleName
+        artifact.locationFile = jarFile
+        artifact.displayName = "com.test:modulea:1.0.0"
+        artifact.type = DependencyType.ETENDOJARMODULE
+        return artifact
+    }
+
+    private File jarWithEntries(List<String> entries) {
+        File jarFile = File.createTempFile('module', '.jar', testProjectDir)
+        new JarOutputStream(new FileOutputStream(jarFile)).withCloseable { JarOutputStream jar ->
+            entries.each { String entryName ->
+                jar.putNextEntry(new JarEntry(entryName))
+                jar.write('<xml/>'.bytes)
+                jar.closeEntry()
+            }
+        }
+        return jarFile
+    }
+}

--- a/src/test/groovy/com/etendoerp/legacy/dependencies/container/ArtifactDependencySpec.groovy
+++ b/src/test/groovy/com/etendoerp/legacy/dependencies/container/ArtifactDependencySpec.groovy
@@ -1,0 +1,21 @@
+package com.etendoerp.legacy.dependencies.container
+
+import spock.lang.Specification
+
+class ArtifactDependencySpec extends Specification {
+
+    def "buildModuleName appends group when artifact is a module suffix"() {
+        expect:
+        ArtifactDependency.buildModuleName('com.etendoerp', 'analytics.exporter') == 'com.etendoerp.analytics.exporter'
+    }
+
+    def "buildModuleName uses artifact when artifact is already the full module package"() {
+        expect:
+        ArtifactDependency.buildModuleName('com.etendoerp', 'com.etendoerp.analytics.exporter') == 'com.etendoerp.analytics.exporter'
+    }
+
+    def "buildModuleName uses artifact when artifact equals group"() {
+        expect:
+        ArtifactDependency.buildModuleName('org.openbravo', 'org.openbravo') == 'org.openbravo'
+    }
+}


### PR DESCRIPTION
## Summary

- Extends `EtendoCoreDependencies` to load and process `dependenciesListMODULESCORE` from `artifacts.list.COMPILATION.gradle`
- Updates `DependencyProcessor` and `ResolverDependencyLoader` to handle MODULES_CORE dependencies in the resolution pipeline
- Adds `DependencyContainer` and `EtendoJarModuleArtifact` support for the new resolution path
- Includes Spock specs covering the new behaviour (`EtendoCoreDependenciesSpec`, `DependencyProcessorModulesCoreSpec`)

## Related

- Jira: ETP-3964
- GitHub: #1017